### PR TITLE
Export routes

### DIFF
--- a/examples/shuttle-example/Cargo.toml
+++ b/examples/shuttle-example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "shuttle-example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+
+
+[dependencies]
+graphul = { path = "../../." }
+shuttle-service = { version = "0.8.0", features = ["web-axum"] }
+sync_wrapper = "0.1"

--- a/examples/shuttle-example/src/lib.rs
+++ b/examples/shuttle-example/src/lib.rs
@@ -1,0 +1,12 @@
+use graphul::{http::Methods, Graphul};
+use sync_wrapper::SyncWrapper;
+
+#[shuttle_service::main]
+async fn graphul() -> shuttle_service::ShuttleAxum {
+    let mut app = Graphul::new();
+
+    app.get("/", || async { "Hello, World 👋!" });
+    let sync_wrapper = SyncWrapper::new(app.export_routes());
+
+    Ok(sync_wrapper)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,12 @@ where
         )
     }
 
+    pub fn export_routes(self) -> Router {
+        self.routes
+            .with_state(self.state)
+            .fallback(Graphul::<S>::fallback)
+    }
+
     pub async fn run(self, addr: &str) {
         let addr: SocketAddr = addr.parse().unwrap();
 


### PR DESCRIPTION
Add a way to export routes from Graphul.
This feature can allow better integration with other libraries compatible with Axum
For example:
https://docs.shuttle.rs/examples/axum
https://github.com/Phosphorus-M/shuttle-graphul
https://hello-world-in-graphul-test.shuttleapp.rs