### PR TITLE
Change tokio version to deploy in shuttle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1.22.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 axum = { version = "0.6", features = ["multipart", "ws", "headers"] }
 askama = "0.11"


### PR DESCRIPTION
Change version of tokio because with the current version in project is not possible to deploy in shuttle
the issue #14 