### PR TITLE
fix: remove tokio to deploy in shuttle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ readme = "README.md"
 
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1.25.0", features = ["full"] }
-tokio-util = { version = "0.7", features = ["io"] }
 axum = { version = "0.6", features = ["multipart", "ws", "headers"] }
 askama = "0.11"
 futures = "0.3.24"


### PR DESCRIPTION
Following the PR #15 we remove tokio from graphul because it's not used anywhere.
This PR solves issue #14  and it allows you to deploy in shuttle.

PS: I reuse your commit @Atticus64 so this counts as a commit for you.